### PR TITLE
Fix sort lessons by period and adjust friday schedule

### DIFF
--- a/app/src/main/java/com/nelsonxilv/gstoutimetable/data/mapper/mappers/LessonDtoMapper.kt
+++ b/app/src/main/java/com/nelsonxilv/gstoutimetable/data/mapper/mappers/LessonDtoMapper.kt
@@ -17,7 +17,7 @@ class LessonDtoMapper @Inject constructor(
         teacher = getTeacherName(data.activityType, data.disciplineDto),
         auditorium = getAuditoriumName(data.auditoriumDto?.name),
         groupNames = mapGroupsDtoToString(data.groupsDto),
-        timeInterval = calculatePeriodTimeInterval(data.period, data.groupsDto),
+        timeInterval = calculatePeriodTimeInterval(data.period, data.groupsDto, data.weekDay),
         activityType = getActivityTypeString(data.activityType),
         period = data.period,
         dayOfWeek = data.weekDay ?: NO_DATA_VALUE,
@@ -43,13 +43,13 @@ class LessonDtoMapper @Inject constructor(
 
     private fun calculatePeriodTimeInterval(
         period: Int,
-        listGroups: List<GroupDto>?
+        listGroups: List<GroupDto>?,
+        weekDay: Int?
     ): TimeInterval {
-        val isFSPO = listGroups?.all { group ->
-            group.instituteDto?.name == FSPO
-        } ?: false
+        val isFSPO = listGroups?.all { it.instituteDto?.name == FSPO } == true
+        val isFriday = weekDay == 5
 
-        return periodToTimeMapper.getPeriodTime(period, isFSPO)
+        return periodToTimeMapper.getPeriodTime(period, isFSPO, isFriday)
     }
 
     private fun getActivityTypeString(activityType: Int?) = when (activityType) {

--- a/app/src/main/java/com/nelsonxilv/gstoutimetable/data/mapper/mappers/PeriodToTimeMapper.kt
+++ b/app/src/main/java/com/nelsonxilv/gstoutimetable/data/mapper/mappers/PeriodToTimeMapper.kt
@@ -25,11 +25,18 @@ class PeriodToTimeMapper @Inject constructor() {
         6 to TimeInterval("15:20", "16:20")
     )
 
-    fun getPeriodTime(period: Int, isFSPO: Boolean): TimeInterval {
-        return if (isFSPO) {
-            periodToTimeForFSPO[period]
-        } else {
-            periodToTime[period]
+    private val fridayPeriodToTime = mapOf(
+        1 to TimeInterval("9:00", "10:20"),
+        2 to TimeInterval("10:30", "11:50"),
+        3 to TimeInterval("14:00", "15:20"),
+        4 to TimeInterval("15:30", "16:50")
+    )
+
+    fun getPeriodTime(period: Int, isFSPO: Boolean, isFriday: Boolean): TimeInterval {
+        return when {
+            isFSPO -> periodToTimeForFSPO[period]
+            isFriday -> fridayPeriodToTime[period]
+            else -> periodToTime[period]
         } ?: TimeInterval("00:00", "00:00")
     }
 }

--- a/app/src/main/java/com/nelsonxilv/gstoutimetable/domain/usecase/GetLessonListForWeekUseCase.kt
+++ b/app/src/main/java/com/nelsonxilv/gstoutimetable/domain/usecase/GetLessonListForWeekUseCase.kt
@@ -19,7 +19,7 @@ class GetLessonListForWeekUseCase @Inject constructor(
 
             allWeekDayList.map { (dayOfWeekNumber, dayName) ->
                 val dayLessons = lessonsByDayOfWeek[dayOfWeekNumber] ?: emptyList()
-                Day(dayName, dayLessons)
+                Day(dayName, dayLessons.sortedBy { it.period })
             }
         }
     }


### PR DESCRIPTION
- Sorted lessons within each day by their period in `GetLessonListForWeekUseCase`.
- Added a separate time mapping for Friday periods in `PeriodToTimeMapper`.
- Modified `LessonDtoMapper` to use the Friday schedule for lessons on Friday.